### PR TITLE
Fix image loading in test script

### DIFF
--- a/rewafer_binarydefect/datasets/folder.py
+++ b/rewafer_binarydefect/datasets/folder.py
@@ -153,7 +153,7 @@ class ImageFolder(Dataset):
         # open path as file to avoid ResourceWarning
         # (https://github.com/python-pillow/Pillow/issues/835)
         with open(path, "rb") as f:
-            sample = Image.open(path).convert("RGB")
+            sample = Image.open(f).convert("RGB")
 
         if self.transform is not None:
             sample = self.transform(sample)

--- a/rewafer_binarydefect/test.py
+++ b/rewafer_binarydefect/test.py
@@ -43,6 +43,6 @@ if __name__ == "__main__":
     opt = opts().parse()
     # Load image
     with open(opt.image_path, "rb") as f:
-        image = Image.open(opt.image_path).convert("RGB")
+        image = Image.open(f).convert("RGB")
     probability = main(opt, image)  # Make prediction
     print("probability:", probability)


### PR DESCRIPTION
## Summary
- use opened file handle in test image loading

## Testing
- `python -m pytest -q`
- `python -m black rewafer_binarydefect/test.py`


------
https://chatgpt.com/codex/tasks/task_e_684cf3697e50832c87870bf11b99bda4